### PR TITLE
Assess times slow down

### DIFF
--- a/Assets/Scripts/Data/SubTasks/DTask_Assess.cs
+++ b/Assets/Scripts/Data/SubTasks/DTask_Assess.cs
@@ -9,11 +9,13 @@ public class DTask_Assess : DTask
 {
     private float assessAmount;
     private float oAssessAmount;
+    private float falloff;
 
     public DTask_Assess(DBuilding dBuilding, float assessAmount, int dMaxPeople, string dName) : base(dBuilding, null, dMaxPeople, dName, 0.0f)
     {
         this.assessAmount = assessAmount;
         oAssessAmount = assessAmount;
+        falloff = .9f;
 
         ForceClean();
         ForceFixed();
@@ -34,7 +36,7 @@ public class DTask_Assess : DTask
                 float modifier = taskSlot.Person.Infection == Constants.MERSON_INFECTION_MIN ? 1 : Constants.MERSON_INFECTION_TASK_MODIFIER;                                
                 building.Assess(assessAmount * Constants.MERSON_INFECTION_TASK_MODIFIER);
 
-                assessAmount = Mathf.Max(assessAmount * .9f, oAssessAmount / 16);
+                assessAmount = Mathf.Max(assessAmount * falloff, oAssessAmount / 16);
             }
         }
     }

--- a/Assets/Scripts/Data/SubTasks/DTask_Assess.cs
+++ b/Assets/Scripts/Data/SubTasks/DTask_Assess.cs
@@ -8,10 +8,12 @@ using SimpleJSON;
 public class DTask_Assess : DTask
 {
     private float assessAmount;
+    private float oAssessAmount;
 
     public DTask_Assess(DBuilding dBuilding, float assessAmount, int dMaxPeople, string dName) : base(dBuilding, null, dMaxPeople, dName, 0.0f)
     {
         this.assessAmount = assessAmount;
+        oAssessAmount = assessAmount;
 
         ForceClean();
         ForceFixed();
@@ -31,6 +33,8 @@ public class DTask_Assess : DTask
             {
                 float modifier = taskSlot.Person.Infection == Constants.MERSON_INFECTION_MIN ? 1 : Constants.MERSON_INFECTION_TASK_MODIFIER;                                
                 building.Assess(assessAmount * Constants.MERSON_INFECTION_TASK_MODIFIER);
+
+                assessAmount = Mathf.Max(assessAmount * .9f, oAssessAmount / 16);
             }
         }
     }


### PR DESCRIPTION
speed reduced by 10% each time assess is done, to a minimum of 1/16 original speed, causing later stages to
come slower.
only issue is that (as I understand it) buildings with fewer tasks may
now take unusually long for initial assessment, but this is minor